### PR TITLE
fix: item properties not working

### DIFF
--- a/source/graphics.cpp
+++ b/source/graphics.cpp
@@ -714,6 +714,7 @@ bool GraphicManager::loadSpriteMetadataFlags(FileReadHandle& file, GameSprite* s
 			case DatFlagWrappable:
 			case DatFlagUnwrappable:
 			case DatFlagTopEffect:
+				break;
 			case DatFlagFloorChange:
 				// verify as idk how to do floorChangeDown etc.
 				//item->floorChange = item->floorChangeDown || item->floorChangeNorth || item->floorChangeEast || item->floorChangeSouth || item->floorChangeWest;
@@ -728,15 +729,15 @@ bool GraphicManager::loadSpriteMetadataFlags(FileReadHandle& file, GameSprite* s
 			case DatFlagWritable:
 				file.skip(2);
 				if(iType) {
-					iType->allowDistRead = true;
 					iType->canReadText = true;
+					iType->canWriteText = true;
 				}
 				break;
 			case DatFlagWritableOnce:
 				file.skip(2);
 				if(iType) {
-					iType->allowDistRead = true;
 					iType->canReadText = true;
+					iType->canWriteText = true;
 				}
 				break;
 			case DatFlagCloth:
@@ -745,7 +746,7 @@ bool GraphicManager::loadSpriteMetadataFlags(FileReadHandle& file, GameSprite* s
 				file.skip(2);
 				break;
 
-			case DatFlagGround:
+			case DatFlagGround: {
 				if(iType) {
 					iType->group = ITEM_GROUP_GROUND;
 				}
@@ -753,6 +754,7 @@ bool GraphicManager::loadSpriteMetadataFlags(FileReadHandle& file, GameSprite* s
 				file.getU16(speed);
                 sType->ground_speed = speed;
 				break;
+			}
 
 			case DatFlagLight: {
 				SpriteLight light;

--- a/source/items.cpp
+++ b/source/items.cpp
@@ -62,6 +62,7 @@ ItemType::ItemType() :
 	hookSouth(false),
 	canReadText(false),
 	canWriteText(false),
+	allowDistRead(false),
 	replaceable(true),
 	decays(false),
 	stackable(false),


### PR DESCRIPTION
Item properties were always displaying 'writeable' properties and causing crash - its because allowDistRead wasnt initialized... should've been initalized with false, instead it was unknown value, causing items to be detected improperly and even leading to crash.

Example of the behaviour this commit **fixes**:
- Right click any container on the map
- Add item to it
- Try to confirm - it will crash. Editing the added item shows 'writeable' instead of e.g. count (for stackables).

Besides fixing by adding ``allowDistRead(false),``, it also improves some other misc changes for more clean dat loading.