### PR TITLE
fix accumulative save of zone ids into the zone files

### DIFF
--- a/source/iomap_otbm.cpp
+++ b/source/iomap_otbm.cpp
@@ -1281,6 +1281,12 @@ bool IOMapOTBM::saveMap(Map& map, NodeFileWriteHandle& f)
 	 * format.
 	 */
 
+	// Clear the zoneMap before collecting zones from tiles to avoid duplicates
+	// TODO this is to be refactored - ::saveMap, the zoneMap shouldn't be like that..
+	// clear and detecting tiles to append to zoneMap, it should be done directly on adding zone
+	// not only at saving time.
+	zoneMap.clear();
+
 	const IOMapOTBM& self = *this;
 
 	FileName tmpName;
@@ -1363,6 +1369,9 @@ bool IOMapOTBM::saveMap(Map& map, NodeFileWriteHandle& f)
 				if(save_tile->getMapFlags()) {
 					f.addByte(OTBM_ATTR_TILE_FLAGS);
 					f.addU32(save_tile->getMapFlags());
+					// TODO this is to be refactored - ::saveMap, the zoneMap shouldn't be like that..
+					// clear and detecting tiles to append to zoneMap, it should be done directly on adding zone
+					// not only at saving time.
 					if (save_tile->getMapFlags() & TILESTATE_ZONE_BRUSH)
 					{
 						for (const auto& zoneId : save_tile->getZoneIds())


### PR DESCRIPTION
Every time the ctrl +s was done in RME, if there were zones to be saved, it would append to the end of the file already saved zones, instead of overriding. This is fixed with the .clear, but this kind of code altogether should be refactored.

On the other hand though, its mostly a waste of time to do such a refactor, as this RME fork will be abandoned at some point in time (planned already).